### PR TITLE
fix: image reactivity

### DIFF
--- a/apps/qwik-demo-app/src/components/image.spec.tsx
+++ b/apps/qwik-demo-app/src/components/image.spec.tsx
@@ -1,0 +1,214 @@
+import { QwikCityMockProvider } from '@builder.io/qwik-city';
+import { createDOM } from '@builder.io/qwik/testing';
+import { expect, test } from 'vitest';
+import { Image, ImageTransformerProps, useImageProvider } from 'qwik-image';
+import { $, Slot, component$ } from '@builder.io/qwik';
+import { providers, selectedProvider } from '../providers';
+
+const TransformerProvider = component$(() => {
+  const imageTransformer$ = $((props: ImageTransformerProps): string => {
+    return providers[selectedProvider].transformer(props);
+  });
+
+  useImageProvider({
+    imageTransformer$,
+  });
+
+  return <Slot />;
+});
+
+const SRC =
+  'image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F869bfbaec9c64415ae68235d9b7b1425';
+
+test(`should render a constrained img`, async () => {
+  const { screen, render } = await createDOM();
+  await render(
+    <QwikCityMockProvider>
+      <TransformerProvider>
+        <Image width={400} height={400} layout="constrained" src={SRC} />
+      </TransformerProvider>
+    </QwikCityMockProvider>
+  );
+
+  validateImg(screen.querySelector('img'), {
+    src: SRC,
+    layout: 'constrained',
+    width: 400,
+    height: 400,
+    srcSizes: [
+      {
+        height: 400,
+        width: 400,
+        breakpoint: 400,
+      },
+      {
+        height: 400,
+        width: 640,
+        breakpoint: 640,
+      },
+      {
+        height: 400,
+        width: 800,
+        breakpoint: 800,
+      },
+    ],
+  });
+});
+
+test(`should render a constrained rectangular img`, async () => {
+  const { screen, render } = await createDOM();
+  await render(
+    <QwikCityMockProvider>
+      <TransformerProvider>
+        <Image width={300} height={200} layout="constrained" src={SRC} />
+      </TransformerProvider>
+    </QwikCityMockProvider>
+  );
+
+  validateImg(screen.querySelector('img'), {
+    width: 300,
+    height: 200,
+    src: SRC,
+    layout: 'constrained',
+    srcSizes: [
+      {
+        height: 200,
+        width: 300,
+        breakpoint: 300,
+      },
+      {
+        height: 200,
+        width: 600,
+        breakpoint: 600,
+      },
+    ],
+  });
+});
+
+test(`should render a fullWidth img`, async () => {
+  const { screen, render } = await createDOM();
+  await render(
+    <QwikCityMockProvider>
+      <TransformerProvider>
+        <Image width={400} height={400} layout="fullWidth" src={SRC} />
+      </TransformerProvider>
+    </QwikCityMockProvider>
+  );
+
+  validateImg(screen.querySelector('img'), {
+    src: SRC,
+    layout: 'fullWidth',
+    width: 400,
+    height: 400,
+    srcSizes: [
+      {
+        height: 400,
+        width: 1280,
+        breakpoint: 1280,
+      },
+      {
+        height: 400,
+        width: 1920,
+        breakpoint: 1920,
+      },
+      {
+        height: 400,
+        width: 3840,
+        breakpoint: 3840,
+      },
+      {
+        height: 400,
+        width: 640,
+        breakpoint: 640,
+      },
+      {
+        height: 400,
+        width: 960,
+        breakpoint: 960,
+      },
+    ],
+  });
+});
+
+test(`should render a fullWidth rectangular img`, async () => {
+  const { screen, render } = await createDOM();
+  await render(
+    <QwikCityMockProvider>
+      <TransformerProvider>
+        <Image width={300} height={200} layout="fullWidth" src={SRC} />
+      </TransformerProvider>
+    </QwikCityMockProvider>
+  );
+
+  validateImg(screen.querySelector('img'), {
+    width: 300,
+    height: 200,
+    src: SRC,
+    layout: 'fullWidth',
+    srcSizes: [
+      {
+        height: 200,
+        width: 1280,
+        breakpoint: 1280,
+      },
+      {
+        height: 200,
+        width: 1920,
+        breakpoint: 1920,
+      },
+      {
+        height: 200,
+        width: 3840,
+        breakpoint: 3840,
+      },
+      {
+        height: 200,
+        width: 640,
+        breakpoint: 640,
+      },
+      {
+        height: 200,
+        width: 960,
+        breakpoint: 960,
+      },
+    ],
+  });
+});
+
+function validateImg(
+  img: HTMLImageElement | null,
+  props: {
+    width: number;
+    height: number;
+    srcSizes: {
+      height: number;
+      width: number;
+      breakpoint: number;
+    }[];
+    src: string;
+    layout: 'constrained' | 'fixed' | 'fullWidth';
+  }
+) {
+  expect(img).toBeTruthy();
+  expect(img?.width).toEqual(props.width);
+  expect(img?.height).toEqual(props.height);
+  expect(img?.src).toEqual(`/${props.src}`);
+
+  const expectedSizes = props.srcSizes
+    .map(
+      ({ width, height, breakpoint }) =>
+        `https://cdn.builder.io/api/v1/${props.src}?height=${height}&width=${width}&format=webp&fit=fill ${breakpoint}w`
+    )
+    .join(',\n');
+  expect(img?.srcset).toEqual(expectedSizes);
+
+  if (props.layout === 'constrained') {
+    expect(img?.outerHTML).toContain(
+      `sizes="(min-width: ${props.width}px) ${props.width}px, 100vw"`
+    );
+  } else if (props.layout === 'fixed') {
+    expect(img?.outerHTML).toContain(`sizes="${props.width}px"`);
+  } else {
+    expect(img?.outerHTML).toContain(`sizes="100vw"`);
+  }
+}

--- a/apps/qwik-demo-app/src/providers.ts
+++ b/apps/qwik-demo-app/src/providers.ts
@@ -1,24 +1,24 @@
-import { ImageTransformerProps } from "qwik-image";
+import { ImageTransformerProps } from 'qwik-image';
 
 export const selectedProvider: keyof typeof providers = 'builder.io';
 
 export const providers: Record<
-	string,
-	{
-		src: string;
-		transformer: ({ src, width, height }: ImageTransformerProps) => string;
-	}
+  string,
+  {
+    src: string;
+    transformer: ({ src, width, height }: ImageTransformerProps) => string;
+  }
 > = {
-	'builder.io': {
-		src: 'image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F869bfbaec9c64415ae68235d9b7b1425',
-		transformer: ({ src, width, height }) => {
-			return `https://cdn.builder.io/api/v1/${src}?height=${height}&width=${width}}&format=webp&fit=fill`;
-		},
-	},
-	cloudflare: {
-		src: 'https://thumbs.dreamstime.com/b/pizza-rustic-italian-mozzarella-cheese-basil-leaves-35669930.jpg',
-		transformer: ({ src, width, height }) => {
-			return `https://that-test.site/cdn-cgi/image/w=${width},h=${height},q=100,fit=contain/${src}`;
-		},
-	},
+  'builder.io': {
+    src: 'image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F869bfbaec9c64415ae68235d9b7b1425',
+    transformer: ({ src, width, height }) => {
+      return `https://cdn.builder.io/api/v1/${src}?height=${height}&width=${width}&format=webp&fit=fill`;
+    },
+  },
+  cloudflare: {
+    src: 'https://thumbs.dreamstime.com/b/pizza-rustic-italian-mozzarella-cheese-basil-leaves-35669930.jpg',
+    transformer: ({ src, width, height }) => {
+      return `https://that-test.site/cdn-cgi/image/w=${width},h=${height},q=100,fit=contain/${src}`;
+    },
+  },
 };

--- a/apps/qwik-demo-app/src/routes/index.tsx
+++ b/apps/qwik-demo-app/src/routes/index.tsx
@@ -1,12 +1,18 @@
-import { component$ } from '@builder.io/qwik';
+import { component$, useSignal } from '@builder.io/qwik';
 import { providers, selectedProvider } from '../providers';
 import { Image } from 'qwik-image';
 
 export default component$(() => {
+  const ref = useSignal<HTMLImageElement>();
+
   return (
     <>
       Selected Provider<h1>{selectedProvider}</h1>
       <Image
+        ref={ref}
+        onLoad$={() => {
+          console.log('loaded');
+        }}
         width={400}
         height={400}
         style={{ border: '2px solid red' }}

--- a/apps/qwik-demo-app/src/routes/index.tsx
+++ b/apps/qwik-demo-app/src/routes/index.tsx
@@ -1,36 +1,6 @@
-import { component$, useSignal } from '@builder.io/qwik';
+import { component$ } from '@builder.io/qwik';
 import { providers, selectedProvider } from '../providers';
-import { Image, ImageProps } from 'qwik-image';
-
-const DynamicImage = component$(
-  (props: { before: ImageProps; after: ImageProps }) => {
-    const width = useSignal(props.before.width);
-    const height = useSignal(props.before.height);
-    const layout = useSignal(props.before.layout);
-    const src = useSignal(props.before.src);
-
-    return (
-      <>
-        <Image
-          width={width.value}
-          height={height.value}
-          layout={layout.value}
-          src={src.value}
-        />
-        <button
-          onClick$={() => {
-            width.value = props.after.width;
-            height.value = props.after.height;
-            layout.value = props.after.layout;
-            src.value = props.after.src;
-          }}
-        >
-          trigger
-        </button>
-      </>
-    );
-  }
-);
+import { Image } from 'qwik-image';
 
 export default component$(() => {
   return (
@@ -43,20 +13,6 @@ export default component$(() => {
         placeholder="#e6e6e6"
         layout="constrained"
         src={providers[selectedProvider].src}
-      />
-      <DynamicImage
-        before={{
-          width: 400,
-          height: 400,
-          layout: 'constrained',
-          src: providers[selectedProvider].src,
-        }}
-        after={{
-          width: 300,
-          height: 200,
-          layout: 'fullWidth',
-          src: providers[selectedProvider].src,
-        }}
       />
     </>
   );

--- a/apps/qwik-demo-app/src/routes/index.tsx
+++ b/apps/qwik-demo-app/src/routes/index.tsx
@@ -1,6 +1,36 @@
-import { component$ } from '@builder.io/qwik';
+import { component$, useSignal } from '@builder.io/qwik';
 import { providers, selectedProvider } from '../providers';
-import { Image } from 'qwik-image';
+import { Image, ImageProps } from 'qwik-image';
+
+const DynamicImage = component$(
+  (props: { before: ImageProps; after: ImageProps }) => {
+    const width = useSignal(props.before.width);
+    const height = useSignal(props.before.height);
+    const layout = useSignal(props.before.layout);
+    const src = useSignal(props.before.src);
+
+    return (
+      <>
+        <Image
+          width={width.value}
+          height={height.value}
+          layout={layout.value}
+          src={src.value}
+        />
+        <button
+          onClick$={() => {
+            width.value = props.after.width;
+            height.value = props.after.height;
+            layout.value = props.after.layout;
+            src.value = props.after.src;
+          }}
+        >
+          trigger
+        </button>
+      </>
+    );
+  }
+);
 
 export default component$(() => {
   return (
@@ -13,6 +43,20 @@ export default component$(() => {
         placeholder="#e6e6e6"
         layout="constrained"
         src={providers[selectedProvider].src}
+      />
+      <DynamicImage
+        before={{
+          width: 400,
+          height: 400,
+          layout: 'constrained',
+          src: providers[selectedProvider].src,
+        }}
+        after={{
+          width: 300,
+          height: 200,
+          layout: 'fullWidth',
+          src: providers[selectedProvider].src,
+        }}
       />
     </>
   );

--- a/packages/qwik-image/src/lib/image.tsx
+++ b/packages/qwik-image/src/lib/image.tsx
@@ -1,6 +1,7 @@
 import {
   QRL,
   QwikIntrinsicElements,
+  Signal,
   component$,
   createContextId,
   useComputed$,
@@ -10,7 +11,7 @@ import {
 
 export const DEFAULT_RESOLUTIONS = [3840, 1920, 1280, 960, 640];
 
-type ImageAttributes = Omit<QwikIntrinsicElements['img'], 'ref'>;
+type ImageAttributes = QwikIntrinsicElements['img'];
 
 /**
  * @alpha
@@ -220,7 +221,10 @@ export const Image = component$<ImageProps>((props) => {
     children: undefined,
   };
 
-  const style = useComputed$(() => ({ ...props.style, ...getStyles(props) }));
+  const style = useComputed$(() => ({
+    ...props.style,
+    ...getStyles(props),
+  }));
   const sizes = useComputed$(() => getSizes(props));
   const srcSet = useComputed$(() => {
     const { src, width, height, aspectRatio, layout } = props;


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [X] Bug
- [ ] Docs / tests
- [ ] Other

# Description

Reactivity is not currently build into the component as values are defined on the component rather than in signals with tasks.
This PR switches to using useComputed$ which automatically tracks changes to dependencies without needing to add a subsequent useTask$. Props can now be updated and the image component will correctly update.

Unfortunately, it's not possible to run this project as the npm scripts are empty, the contributing guide seems out of date, and I don't have experience with NX so i cant run it. The test scripts also don't exist.

I hope this PR means we can update the contributing guide so it works correctly, or if one of the maintainers could test and run this PR. Alternatively please feel free to reach out to me to get this change over the line

This attempts to fix https://github.com/qwikifiers/qwik-image/issues/2

# Use cases and why

- 1. Changing the src of an image when an onError$ callback is triggered will become possible
- 2. Changing the layout or sizes based on some other runtime logic will be possible

# Screenshots/Demo

<!-- Add your screenshots here -->

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-image/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
