### PR TITLE
feat: add fetchpriority property

### DIFF
--- a/packages/qwik-image/src/lib/image.tsx
+++ b/packages/qwik-image/src/lib/image.tsx
@@ -1,7 +1,6 @@
 import {
   QRL,
   QwikIntrinsicElements,
-  Signal,
   component$,
   createContextId,
   useComputed$,
@@ -46,7 +45,7 @@ export interface ImageProps extends ImageAttributes {
     | 'scale-down'
     | 'inherit'
     | 'initial';
-  fetchpriority?:'low' | 'high'
+  fetchpriority?: 'low' | 'high' | 'auto';
 }
 
 export const ImageContext = createContextId<ImageState>('ImageContext');

--- a/packages/qwik-image/src/lib/image.tsx
+++ b/packages/qwik-image/src/lib/image.tsx
@@ -46,6 +46,7 @@ export interface ImageProps extends ImageAttributes {
     | 'scale-down'
     | 'inherit'
     | 'initial';
+  fetchpriority?:'low' | 'high'
 }
 
 export const ImageContext = createContextId<ImageState>('ImageContext');


### PR DESCRIPTION
fetchpriority is one the essential values as img attribute in order to improve page LCP.

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests
- [ ] Other

# Description

**fetchpriority** is one the essential values for img element in order to improve page LCP score.